### PR TITLE
Make local testing easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,29 +22,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir -p /build/openssl
 RUN curl -s https://www.openssl.org/source/openssl-1.0.0t.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.0.0t && \
-    ./config \
+    ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.0 \
-      shared && \
+      shared debug-linux-x86_64 && \
     make && make install
 
 RUN curl -s https://www.openssl.org/source/openssl-1.0.1t.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.0.1t && \
-    ./config \
+    ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.1 \
-      shared && \
+      shared debug-linux-x86_64 && \
     make && make install
 
 RUN curl -s https://www.openssl.org/source/openssl-1.0.2h.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.0.2h && \
-    ./config \
+    ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.2 \
-      shared && \
+      shared debug-linux-x86_64 && \
     make && make install
 
 RUN curl -s https://www.openssl.org/source/openssl-1.1.0-pre6.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.1.0-pre6 && \
-    ./config \
-      --prefix=/opt/openssl/openssl-1.1.0 && \
+    ./Configure \
+      --prefix=/opt/openssl/openssl-1.1.0 \
+      enable-crypto-mdebug enable-crypto-mdebug-backtrace \
+      debug-linux-x86_64 && \
     make && make install
 
 # Supported libressl versions: 2.1, 2.2, 2.3, 2.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,21 +25,21 @@ RUN curl -s https://www.openssl.org/source/openssl-1.0.0t.tar.gz | tar -C /build
     ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.0 \
       shared debug-linux-x86_64 && \
-    make && make install
+    make && make install_sw
 
 RUN curl -s https://www.openssl.org/source/openssl-1.0.1t.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.0.1t && \
     ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.1 \
       shared debug-linux-x86_64 && \
-    make && make install
+    make && make install_sw
 
 RUN curl -s https://www.openssl.org/source/openssl-1.0.2h.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.0.2h && \
     ./Configure \
       --openssldir=/opt/openssl/openssl-1.0.2 \
       shared debug-linux-x86_64 && \
-    make && make install
+    make && make install_sw
 
 RUN curl -s https://www.openssl.org/source/openssl-1.1.0-pre6.tar.gz | tar -C /build/openssl -xzf - && \
     cd /build/openssl/openssl-1.1.0-pre6 && \
@@ -47,7 +47,7 @@ RUN curl -s https://www.openssl.org/source/openssl-1.1.0-pre6.tar.gz | tar -C /b
       --prefix=/opt/openssl/openssl-1.1.0 \
       enable-crypto-mdebug enable-crypto-mdebug-backtrace \
       debug-linux-x86_64 && \
-    make && make install
+    make && make install_sw
 
 # Supported libressl versions: 2.1, 2.2, 2.3, 2.4
 RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.10.tar.gz | tar -C /build/openssl -xzf -

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,63 +19,68 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zlib1g-dev
 
 # Supported OpenSSL versions: 1.0.0, 1.0.1, 1.0.2, 1.1.0
-RUN mkdir -p /build/openssl && \
-    curl -s https://www.openssl.org/source/openssl-1.0.0t.tar.gz | tar -C /build/openssl -xzf - && \
-    cd build/openssl/openssl-1.0.0t && \
+RUN mkdir -p /build/openssl
+RUN curl -s https://www.openssl.org/source/openssl-1.0.0t.tar.gz | tar -C /build/openssl -xzf - && \
+    cd /build/openssl/openssl-1.0.0t && \
     ./config \
-      --openssldir=/opt/openssl/openssl-1.0.0t \
+      --openssldir=/opt/openssl/openssl-1.0.0 \
       shared && \
     make && make install
 
 RUN curl -s https://www.openssl.org/source/openssl-1.0.1t.tar.gz | tar -C /build/openssl -xzf - && \
-    cd build/openssl/openssl-1.0.1t && \
+    cd /build/openssl/openssl-1.0.1t && \
     ./config \
-       --openssldir=/opt/openssl/openssl-1.0.1t \
-       shared && \
+      --openssldir=/opt/openssl/openssl-1.0.1 \
+      shared && \
     make && make install
 
 RUN curl -s https://www.openssl.org/source/openssl-1.0.2h.tar.gz | tar -C /build/openssl -xzf - && \
-    cd build/openssl/openssl-1.0.2h && \
+    cd /build/openssl/openssl-1.0.2h && \
     ./config \
-       --openssldir=/opt/openssl/openssl-1.0.2h \
-       shared && \
+      --openssldir=/opt/openssl/openssl-1.0.2 \
+      shared && \
     make && make install
 
 RUN curl -s https://www.openssl.org/source/openssl-1.1.0-pre6.tar.gz | tar -C /build/openssl -xzf - && \
-    cd build/openssl/openssl-1.1.0-pre6 && \
+    cd /build/openssl/openssl-1.1.0-pre6 && \
     ./config \
-       --prefix=/opt/openssl/openssl-1.1.0-pre6 && \
+      --prefix=/opt/openssl/openssl-1.1.0 && \
     make && make install
 
 # Supported libressl versions: 2.1, 2.2, 2.3, 2.4
-RUN mkdir -p /build/libressl
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.10.tar.gz | tar -C /build/libressl -xzf -
-RUN cd /build/libressl/libressl-2.1.10 && \
-  ./configure --prefix=/opt/libressl/libressl-2.1.10 && make && make install
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.10.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.1.10 && \
+    ./configure \
+      --prefix=/opt/openssl/libressl-2.1 && \
+    make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.9.tar.gz | tar -C /build/libressl -xzf -
-RUN cd /build/libressl/libressl-2.2.9 && \
-  ./configure --prefix=/opt/libressl/libressl-2.2.9 && make && make install
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.2.9.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.2.9 && \
+    ./configure \
+      --prefix=/opt/openssl/libressl-2.2 && \
+    make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.7.tar.gz | tar -C /build/libressl -xzf -
-RUN cd /build/libressl/libressl-2.3.7 && \
-  ./configure --prefix=/opt/libressl/libressl-2.3.7 && make && make install
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.3.7.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.3.7 && \
+    ./configure \
+      --prefix=/opt/openssl/libressl-2.3 && \
+    make && make install
 
-RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.2.tar.gz | tar -C /build/libressl -xzf -
-RUN cd /build/libressl/libressl-2.4.2 && \
-  ./configure --prefix=/opt/libressl/libressl-2.4.2 && make && make install
+RUN curl -s http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.2.tar.gz | tar -C /build/openssl -xzf -
+RUN cd /build/openssl/libressl-2.4.2 && \
+    ./configure \
+      --prefix=/opt/openssl/libressl-2.4 && \
+    make && make install
 
-# Supported Ruby versions: 2.3.1
-RUN mkdir -p /build/ruby && \
-    curl -s https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz | tar -C /build/ruby -xzf - && \
+# Supported Ruby versions: 2.3
+RUN mkdir -p /build/ruby
+RUN curl -s https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz | tar -C /build/ruby -xzf - && \
     cd /build/ruby/ruby-2.3.1 && \
     autoconf && ./configure \
       --without-openssl \
-      --prefix=/opt/ruby/ruby-2.3.1 \
+      --prefix=/opt/ruby/ruby-2.3 \
       --disable-install-doc && \
     make && make install
-
-ENV PATH /opt/ruby/ruby-2.3.1/bin:$PATH
 
 ONBUILD WORKDIR /home/openssl/code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libreadline-dev \
   make \
   patch \
+  pkg-config \
   sed \
   xz-utils \
   zlib1g-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN curl -s https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz | tar -C 
       --disable-install-doc && \
     make && make install
 
+ONBUILD ADD . /home/openssl/code
 ONBUILD WORKDIR /home/openssl/code
 
 COPY init.sh /home/openssl/init.sh

--- a/init.sh
+++ b/init.sh
@@ -15,7 +15,15 @@ export PATH="/opt/ruby/${RUBY_VERSION}/bin:$PATH"
 export LD_LIBRARY_PATH="/opt/openssl/${OPENSSL_VERSION}/lib"
 export PKG_CONFIG_PATH="/opt/openssl/${OPENSSL_VERSION}/lib/pkgconfig"
 
-gem build openssl.gemspec
-gem install --development --clear-sources -s http://rubygems.org openssl-*.gem -- --with-openssl-dir=/opt/openssl/$OPENSSL_VERSION
+ruby -e '
+  newsource = Gem::Source.new("http://rubygems.org")
+  Gem.sources.replace([newsource])
+  Gem.configuration.write
+
+  spec = eval(File.read("openssl.gemspec"))
+  spec.development_dependencies.each do |dep|
+    Gem.install(dep.name, dep.requirement, force: true)
+  end
+'
 
 exec $*

--- a/init.sh
+++ b/init.sh
@@ -12,6 +12,8 @@ fi
 
 echo "Using Ruby ${RUBY_VERSION} with OpenSSL ${OPENSSL_VERSION}."
 export PATH="/opt/ruby/${RUBY_VERSION}/bin:$PATH"
+export LD_LIBRARY_PATH="/opt/openssl/${OPENSSL_VERSION}/lib"
+export PKG_CONFIG_PATH="/opt/openssl/${OPENSSL_VERSION}/lib/pkgconfig"
 
 gem build openssl.gemspec
 gem install --development --clear-sources -s http://rubygems.org openssl-*.gem -- --with-openssl-dir=/opt/openssl/$OPENSSL_VERSION

--- a/init.sh
+++ b/init.sh
@@ -1,22 +1,19 @@
 #!/bin/bash
 
-if [[ "$OPENSSL_VERSION" != "" ]]
+if [[ "$RUBY_VERSION" = "" ]]
 then
-  echo "Using Ruby ${RUBY_VERSION} with OpenSSL ${OPENSSL_VERSION}."
-  export PATH="/opt/ruby/ruby-${RUBY_VERSION}/bin:$PATH"
-elif [[ "$LIBRESSL_VERSION" != "" ]]
-then
-  echo "Using Ruby ${RUBY_VERSION} with LibreSSL ${LIBRESSL_VERSION}."
-  export PATH="/opt/ruby/ruby-${RUBY_VERSION}/bin:$PATH"
+  RUBY_VERSION=ruby-2.3
 fi
 
-gem build openssl.gemspec
-if [[ "$OPENSSL_VERSION" != "" ]]
+if [[ "$OPENSSL_VERSION" = "" ]]
 then
-  gem install --development --clear-sources -s http://rubygems.org openssl-*.gem -- --with-openssl-dir=/opt/openssl/openssl-$OPENSSL_VERSION
-elif [[ "$LIBRESSL_VERSION" != "" ]]
-then
-  gem install --development --clear-sources -s http://rubygems.org openssl-*.gem -- --with-openssl-dir=/opt/libressl/libressl-$LIBRESSL_VERSION
+  OPENSSL_VERSION=openssl-1.0.2
 fi
+
+echo "Using Ruby ${RUBY_VERSION} with OpenSSL ${OPENSSL_VERSION}."
+export PATH="/opt/ruby/${RUBY_VERSION}/bin:$PATH"
+
+gem build openssl.gemspec
+gem install --development --clear-sources -s http://rubygems.org openssl-*.gem -- --with-openssl-dir=/opt/openssl/$OPENSSL_VERSION
 
 exec $*


### PR DESCRIPTION
This makes local testing easier:
1. OPENSSL_VERSION and LIBRESSL_VERSION are merged, and have default value.
2. Local directory is not mounted on the container but just copied - currently running `docker-compose run test` leaves garbage on the host.

travis build will look like this: https://travis-ci.org/rhenium/ruby-openssl/builds/152899879
